### PR TITLE
Fix when used in a subdir of a workspace

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -16,3 +16,7 @@ branch = "master"
 [dependencies.clap]
 version = "2.33.0"
 default-features = false
+
+# Make sure this crate still compiles while it is checked out
+# in a sub-directory of a repository that has a Cargo.toml. 
+[workspace]


### PR DESCRIPTION
Make sure corrosion works when it is checked out in a sub-directory of a repository with 
a Cargo.toml workspace

For example, in my case, My repository's root has both a Cargo.toml and a CMakeLists.txt,
and i'm using the `FetchContent` feature to check out corrosion.
However, this does not work with the common practice to put the build repository in a 
sub-directory of the source directory, otherwise the build fails with 

```
error: current package believes it's in a workspace when it's not:
current:   /foo/bar/build/_deps/corrosion-src/generator/Cargo.toml
workspace: /foo/bar/Cargo.toml

this may be fixable by adding `build/_deps/corrosion-src/generator` to the `workspace.members` array of the manifest located at: /foo/bar/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
CMake Error at build/_deps/corrosion-src/cmake/Corrosion.cmake:209 (message):
  corrosion-generator failed: 101
```
Presumably, one would have the same problem when using git submodules, and also when using the source dir as a build directory

Adding an empty `[workspace]`  fixes the issue.