### PR TITLE
Use JOB_POOL to avoid running cargo in parallel

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -24,6 +24,8 @@ get_property(
     TARGET Rust::Cargo PROPERTY IMPORTED_LOCATION
 )
 
+set_property(GLOBAL APPEND PROPERTY JOB_POOLS corrosion_cargo_pool=1)
+
 if (NOT TARGET Corrosion::Generator)
     set(_CORROSION_GENERATOR_EXE
         ${CARGO_EXECUTABLE} run --quiet --manifest-path "${CMAKE_CURRENT_LIST_DIR}/../generator/Cargo.toml" --)
@@ -167,6 +169,7 @@ function(_add_cargo_build)
         # The build is conducted in root build directory so that cargo
         # dependencies are shared
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
+        JOB_POOL corrosion_cargo_pool
     )
 
     add_custom_target(
@@ -175,6 +178,7 @@ function(_add_cargo_build)
             $<TARGET_FILE:Rust::Cargo> clean --target ${_CORROSION_RUST_CARGO_TARGET}
             -p ${package_name} --manifest-path ${path_to_toml}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
+        JOB_POOL corrosion_cargo_pool
     )
     
     if (NOT TARGET cargo-clean)

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -147,6 +147,12 @@ function(_add_cargo_build)
         endforeach()
     endif()
 
+    if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+        set(set_corrosion_cargo_pool)
+    else()
+        set(set_corrosion_cargo_pool JOB_POOL corrosion_cargo_pool)
+    endif()
+
     add_custom_target(
         cargo-build_${target_name}
         ALL
@@ -169,7 +175,7 @@ function(_add_cargo_build)
         # The build is conducted in root build directory so that cargo
         # dependencies are shared
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
-        JOB_POOL corrosion_cargo_pool
+        ${set_corrosion_cargo_pool}
     )
 
     add_custom_target(
@@ -178,7 +184,7 @@ function(_add_cargo_build)
             $<TARGET_FILE:Rust::Cargo> clean --target ${_CORROSION_RUST_CARGO_TARGET}
             -p ${package_name} --manifest-path ${path_to_toml}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
-        JOB_POOL corrosion_cargo_pool
+        ${set_corrosion_cargo_pool}
     )
     
     if (NOT TARGET cargo-clean)


### PR DESCRIPTION
Ninja supports the concept of job pools so that cargo is not run in parallel.
Otherwise, we see a lot of
```
Blocking waiting for file lock on build directory
```