### PR TITLE
Use more standard install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
 
     corrosion_install(
         TARGETS corrosion-generator
-        DESTINATION Corrosion/libexec
+        DESTINATION libexec
     )
 
     # Generate the Config file
@@ -62,7 +62,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
 
     configure_package_config_file(
         cmake/CorrosionConfig.cmake.in CorrosionConfig.cmake
-        INSTALL_DESTINATION Corrosion/lib/cmake/Corrosion
+        INSTALL_DESTINATION lib/cmake/Corrosion
     )
 
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
@@ -80,7 +80,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/CorrosionConfig.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/CorrosionConfigVersion.cmake
-        DESTINATION Corrosion/lib/cmake/Corrosion
+        DESTINATION lib/cmake/Corrosion
     )
 
     # These CMake scripts are needed both for the install and as a subdirectory
@@ -89,6 +89,6 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
             cmake/Corrosion.cmake
             cmake/FindRust.cmake
         DESTINATION
-            Corrosion/share/cmake
+            share/cmake
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ endif()
 
 # Installation
 # If Corrosion is a subdirectory, do not enable its install code
+
+include(GNUInstallDirs)
+
 if (NOT CORROSION_IS_SUBDIRECTORY)
     # Builds the generator executable
     corrosion_import_crate(MANIFEST_PATH generator/Cargo.toml)
@@ -54,7 +57,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
 
     corrosion_install(
         TARGETS corrosion-generator
-        DESTINATION libexec
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
     )
 
     # Generate the Config file
@@ -62,7 +65,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
 
     configure_package_config_file(
         cmake/CorrosionConfig.cmake.in CorrosionConfig.cmake
-        INSTALL_DESTINATION lib/cmake/Corrosion
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Corrosion
     )
 
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
@@ -80,7 +83,7 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/CorrosionConfig.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/CorrosionConfigVersion.cmake
-        DESTINATION lib/cmake/Corrosion
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Corrosion
     )
 
     # These CMake scripts are needed both for the install and as a subdirectory
@@ -89,6 +92,6 @@ if (NOT CORROSION_IS_SUBDIRECTORY)
             cmake/Corrosion.cmake
             cmake/FindRust.cmake
         DESTINATION
-            share/cmake
+            ${CMAKE_INSTALL_DATADIR}/cmake
     )
 endif()

--- a/cmake/CorrosionConfig.cmake.in
+++ b/cmake/CorrosionConfig.cmake.in
@@ -4,11 +4,11 @@ if (Corrosion_FOUND)
     return()
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/share/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/cmake")
 
 add_executable(Corrosion::Generator IMPORTED GLOBAL)
 set_property(
     TARGET Corrosion::Generator
-    PROPERTY IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/libexec/corrosion-generator")
+    PROPERTY IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBEXECDIR@/corrosion-generator")
 
 include(Corrosion)

--- a/cmake/CorrosionConfig.cmake.in
+++ b/cmake/CorrosionConfig.cmake.in
@@ -4,11 +4,11 @@ if (Corrosion_FOUND)
     return()
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/Corrosion/share/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/share/cmake")
 
 add_executable(Corrosion::Generator IMPORTED GLOBAL)
 set_property(
     TARGET Corrosion::Generator
-    PROPERTY IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/Corrosion/libexec/corrosion-generator")
+    PROPERTY IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/libexec/corrosion-generator")
 
 include(Corrosion)


### PR DESCRIPTION
Use GNUInstallDirs, which should improve compatibility with install layouts across different Linux distributions.
I'm considering to use corrision in a project that is potentially going to be packaged in some distributions, so the install paths need to be standard.