### PR TITLE
If MANIFEST_PATH is unwrapped, it should be required.

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("manifest-path")
                 .value_name("Cargo.toml")
                 .help("Specifies the target Cargo project")
+                .required(true)
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
Otherwise, the user gets to see a nice panic message instead of
something short and actionable.