### PR TITLE
Get rid of unwrap() on cargo_metadata exec().

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cmd.manifest_path(manifest_path);
     cmd.cargo_path(cargo_executable);
 
-    let metadata = cmd.exec().unwrap();
+    let metadata = cmd.exec()?;
 
     let shared_args = GeneratorSharedArgs {
         manifest_path: manifest_path.into(),


### PR DESCRIPTION
Again, a panic message is probably hard to read here.