### PR TITLE
Use `USES_TERMINAL` instead of job pools

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -24,8 +24,6 @@ get_property(
     TARGET Rust::Cargo PROPERTY IMPORTED_LOCATION
 )
 
-set_property(GLOBAL APPEND PROPERTY JOB_POOLS corrosion_cargo_pool=1)
-
 if (NOT TARGET Corrosion::Generator)
     set(_CORROSION_GENERATOR_EXE
         ${CARGO_EXECUTABLE} run --quiet --manifest-path "${CMAKE_CURRENT_LIST_DIR}/../generator/Cargo.toml" --)
@@ -156,12 +154,6 @@ function(_add_cargo_build)
         endif()
     endforeach()
 
-    if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
-        set(set_corrosion_cargo_pool)
-    else()
-        set(set_corrosion_cargo_pool JOB_POOL corrosion_cargo_pool)
-    endif()
-
     add_custom_target(
         cargo-build_${target_name}
         ALL
@@ -191,7 +183,7 @@ function(_add_cargo_build)
         # The build is conducted in root build directory so that cargo
         # dependencies are shared
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
-        ${set_corrosion_cargo_pool}
+        USES_TERMINAL
     )
 
     add_custom_target(
@@ -200,7 +192,7 @@ function(_add_cargo_build)
             $<TARGET_FILE:Rust::Cargo> clean --target ${_CORROSION_RUST_CARGO_TARGET}
             -p ${package_name} --manifest-path ${path_to_toml}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${build_dir}
-        ${set_corrosion_cargo_pool}
+        USES_TERMINAL
     )
 
     if (NOT TARGET cargo-clean)


### PR DESCRIPTION
This will make sure that ninja does not buffer all the output from cargo
so that the user can see cargo progress in the terminal as the build
proceeds.