### PR TITLE
Fix unnecessary rebuilds when using CORROSION_USE_HOST_BUILD

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -60,6 +60,7 @@ set(
 
 set(_CORROSION_CARGO_VERSION ${Rust_CARGO_VERSION} CACHE INTERNAL "cargo version used by corrosion")
 set(_CORROSION_RUST_CARGO_TARGET ${Rust_CARGO_TARGET} CACHE INTERNAL "target triple used by corrosion")
+set(_CORROSION_RUST_CARGO_HOST_TARGET ${Rust_CARGO_HOST_TARGET} CACHE INTERNAL "host triple used by corrosion")
 
 function(_add_cargo_build)
     set(options "")
@@ -177,11 +178,11 @@ function(_add_cargo_build)
 
         set(linker_languages "$<${if_not_host_build_condition}:${linker_languages}>")
         set(corrosion_link_args "$<${if_not_host_build_condition}:${corrosion_link_args}>")
-        set(cargo_target_option "$<${if_not_host_build_condition}:${cargo_target_option}>")
+        set(cargo_target_option "$<IF:${if_not_host_build_condition},${cargo_target_option},--target=${_CORROSION_RUST_CARGO_HOST_TARGET}>")
 
         file(GENERATE OUTPUT "debug-${target_name}.txt" CONTENT "$<TARGET_PROPERTY:${target_name},CORROSION_USE_HOST_BUILD>")
 
-        set(target_artifact_dir "$<${if_not_host_build_condition}:${target_artifact_dir}>")
+        set(target_artifact_dir "$<IF:${if_not_host_build_condition},${target_artifact_dir},${_CORROSION_RUST_CARGO_HOST_TARGET}>")
     endif()
 
     set(cargo_build_dir "${CMAKE_BINARY_DIR}/${build_dir}/cargo/build/${target_artifact_dir}/${build_type_dir}")

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -179,9 +179,6 @@ function(_add_cargo_build)
         set(linker_languages "$<${if_not_host_build_condition}:${linker_languages}>")
         set(corrosion_link_args "$<${if_not_host_build_condition}:${corrosion_link_args}>")
         set(cargo_target_option "$<IF:${if_not_host_build_condition},${cargo_target_option},--target=${_CORROSION_RUST_CARGO_HOST_TARGET}>")
-
-        file(GENERATE OUTPUT "debug-${target_name}.txt" CONTENT "$<TARGET_PROPERTY:${target_name},CORROSION_USE_HOST_BUILD>")
-
         set(target_artifact_dir "$<IF:${if_not_host_build_condition},${target_artifact_dir},${_CORROSION_RUST_CARGO_HOST_TARGET}>")
     endif()
 

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -72,7 +72,7 @@ endif()
 # best source for a Rust toolchain was determined to be_.
 
 # List of user variables that will override any toolchain-provided setting
-set(_Rust_USER_VARS Rust_COMPILER Rust_CARGO Rust_CARGO_TARGET)
+set(_Rust_USER_VARS Rust_COMPILER Rust_CARGO Rust_CARGO_TARGET Rust_CARGO_HOST_TARGET)
 foreach(_VAR ${_Rust_USER_VARS})
     if (DEFINED ${_VAR})
         set(${_VAR}_CACHED ${${_VAR}} CACHE INTERNAL "Internal cache of ${_VAR}")
@@ -221,6 +221,7 @@ endif()
 
 if (_RUSTC_VERSION_RAW MATCHES "host: ([a-zA-Z0-9_\\-]*)\n")
     set(Rust_DEFAULT_HOST_TARGET "${CMAKE_MATCH_1}")
+    set(Rust_CARGO_HOST_TARGET_CACHED "${Rust_DEFAULT_HOST_TARGET}" CACHE STRING "Host triple")
 else()
     message(
         FATAL_ERROR
@@ -298,7 +299,7 @@ endforeach()
 
 find_package_handle_standard_args(
     Rust
-    REQUIRED_VARS Rust_COMPILER Rust_VERSION Rust_CARGO Rust_CARGO_VERSION Rust_CARGO_TARGET
+    REQUIRED_VARS Rust_COMPILER Rust_VERSION Rust_CARGO Rust_CARGO_VERSION Rust_CARGO_TARGET Rust_CARGO_HOST_TARGET
     VERSION_VAR Rust_VERSION)
 
 function(_gen_config config_type use_config_dir)

--- a/generator/src/subcommands/build_crate.rs
+++ b/generator/src/subcommands/build_crate.rs
@@ -16,7 +16,7 @@ pub fn subcommand() -> App<'static, 'static> {
             Arg::with_name(TARGET)
                 .long("target")
                 .value_name("TRIPLE")
-                .required(false)
+                .required(true)
                 .help("The target triple to build for"),
         )
         .arg(
@@ -32,23 +32,15 @@ pub fn invoke(
     args: &crate::GeneratorSharedArgs,
     matches: &ArgMatches,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let target = matches.value_of(TARGET);
+    let target = matches.value_of(TARGET).unwrap();
 
     let mut cargo = process::Command::new(&args.cargo_executable);
 
     cargo.args(&[
-        "build"
-    ]);
-
-    if let Some(target) = target {
-        cargo.args(&[
+        "build",
         "--target",
-        target
-    ]);
-    }
-
-    cargo.args(&[
-            "--package",
+        target,
+        "--package",
         matches.value_of(PACKAGE).unwrap(),
         "--manifest-path",
         args.manifest_path.to_str().unwrap(),
@@ -68,8 +60,6 @@ pub fn invoke(
         .split(" ")
         .map(Into::into)
         .collect();
-
-    let target = target.unwrap_or_default();
 
     if !languages.is_empty() {
         let mut rustflags = "-C default-linker-libraries=yes".to_owned();


### PR DESCRIPTION
Commit 3c9ff60f51cac21fcd4add47c1a14da47fe1c02e introduced the feature
that host binaries can be built, which is done by omitting the
`--target` parameter to cargo. This however implies that the target host
directory is picked by cargo (for example `cargo/build/debug`) for these
builds, which ends up being shared with the corrosion build itself, as
that is built implicitly via `cargo run`. If there were any common
crates as dependencies, then those may end up being built with different
flags (for corrosion and for host builds of the project), resulting in
unnecessary rebuilds.

To fix this, this patch makes use of the internal knowledge about the
host target by always passing it again.