### PR TITLE
Allow using FindRust.cmake several times

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -340,14 +340,16 @@ else()
     _gen_config(Debug OFF)
 endif()
 
-add_executable(Rust::Rustc IMPORTED GLOBAL)
-set_property(
-    TARGET Rust::Rustc
-    PROPERTY IMPORTED_LOCATION ${Rust_COMPILER_CACHED}
-)
+if(NOT TARGET Rust::Rustc)
+    add_executable(Rust::Rustc IMPORTED GLOBAL)
+    set_property(
+        TARGET Rust::Rustc
+        PROPERTY IMPORTED_LOCATION ${Rust_COMPILER_CACHED}
+    )
 
-add_executable(Rust::Cargo IMPORTED GLOBAL)
-set_property(
-    TARGET Rust::Cargo
-    PROPERTY IMPORTED_LOCATION ${Rust_CARGO_CACHED}
-)
+    add_executable(Rust::Cargo IMPORTED GLOBAL)
+    set_property(
+        TARGET Rust::Cargo
+        PROPERTY IMPORTED_LOCATION ${Rust_CARGO_CACHED}
+    )
+endif()

--- a/test/config/FindRust/CMakeLists.txt
+++ b/test/config/FindRust/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+cmake_minimum_required(VERSION 3.12)
+project(FindRust LANGUAGES CXX)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake" ${CMAKE_MODULE_PATH})
+
+# make sure find_package(Rust) can be used more than once
+find_package(Rust REQUIRED)
+find_package(Rust REQUIRED)

--- a/test/config/FindRust/Test.cmake
+++ b/test/config/FindRust/Test.cmake
@@ -1,0 +1,14 @@
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
+    set(CE COMMAND_ECHO STDOUT)
+endif()
+
+execute_process(
+    COMMAND
+        ${CMAKE_COMMAND} ${CMAKE_CURRENT_LIST_DIR}
+    ${CE}
+    RESULT_VARIABLE SUCCESS
+)
+
+if (NOT SUCCESS EQUAL 0)
+    message(FATAL_ERROR)
+endif()


### PR DESCRIPTION
CMake only allows creating alias targets once, otherwise it bails out with
CMake Error at thirdparty/corrosion/cmake/FindRust.cmake:330 (add_executable):
  add_executable cannot create imported target "Rust::Rustc" because another
  target with the same name already exists.

Allow using find_package(Rust) in several places by following the pattern of other
find modules, protecting with an if.
