### PR TITLE
Partially fix build with CMake 3.13 on Debian 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ configure_package_config_file(
         ${CORROSION_INSTALL_PREFIX}${CMAKE_INSTALL_LIBDIR}/cmake/Corrosion
 )
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
     set(arch_independent ARCH_INDEPENDENT)
 endif()
 


### PR DESCRIPTION
The parameter ARCH_INDEPENDANT  to `write_basic_package_version_file`
is not available on cmake 3.13, but only starting with 3.14.
See the Documentation for [3.13 here](https://cmake.org/cmake/help/v3.13/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file)
and for [3.14 here](https://cmake.org/cmake/help/v3.14/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file)

This partially fixes the build on Debian 10 buster with the default Cmake v3.13.

I tested in a VM provisoned by Vagrant with the following Vagrantfile:


```
$dependency_script=<<-SCRIPT
echo "Start Provisioning"
apt update
apt install -y build-essential cmake git curl
SCRIPT

$user_dependency_script=<<-SCRIPT
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

git clone https://github.com/jschwe/corrosion.git
cd corrosion && git checkout fix-cmake3-13 && cd ..
cmake -Scorrosion -Bbuild -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release
sudo cmake --install build --config Release
SCRIPT

Vagrant.configure("2") do |config|  
    config.vm.box = "debian/buster64"
    config.vm.provision "shell", inline: $dependency_script
    config.vm.provision "shell", inline: $user_dependency_script,  privileged: false

end
```

There is still a different error that fails the build when running the `cmake --build build --config Release` step:, but I think it is unrelated to my change.
<details>
 <summary>Log of the `cmake --build build --config Release` step</summary>

```
vagrant@buster:~$ cmake --build build --config Release
Scanning dependencies of target cargo-build_corrosion-generator
   Compiling proc-macro2 v1.0.26
   Compiling unicode-xid v0.2.1
   Compiling syn v1.0.71
   Compiling serde_derive v1.0.125
   Compiling serde v1.0.125
   Compiling ryu v1.0.5
   Compiling ucd-trie v0.1.3
   Compiling bitflags v1.2.1
   Compiling camino v1.0.4
   Compiling serde_json v1.0.64
   Compiling platforms v1.1.0
   Compiling itoa v0.4.7
   Compiling unicode-width v0.1.8
   Compiling pest v2.1.3
   Compiling textwrap v0.11.0
   Compiling quote v1.0.9
   Compiling semver-parser v0.10.2
   Compiling clap v2.33.3
   Compiling cargo-platform v0.1.1
   Compiling semver v0.11.0
   Compiling cargo_metadata v0.13.1
   Compiling corrosion-generator v0.1.0 (/home/vagrant/corrosion/generator)
    Finished release [optimized] target(s) in 37.65s
[  0%] Built target cargo-build_corrosion-generator
Scanning dependencies of target cpp-lib
[ 16%] Building CXX object test/cpp2rust/CMakeFiles/cpp-lib.dir/lib.cpp.o
[ 33%] Linking CXX static library libcpp-lib.a
[ 33%] Built target cpp-lib
Scanning dependencies of target cargo-build_rust-exe
   Compiling corrosion-build v0.1.0 (/home/vagrant/corrosion/integrator)
   Compiling rust-exe v0.1.0 (/home/vagrant/corrosion/test/cpp2rust/rust)
    Finished release [optimized] target(s) in 0.63s
[ 33%] Built target cargo-build_rust-exe
Scanning dependencies of target cargo-build_rust-lib
   Compiling rust-lib v0.1.0 (/home/vagrant/corrosion/test/rust2cpp/rust)
    Finished release [optimized] target(s) in 0.10s
[ 33%] Built target cargo-build_rust-lib
Scanning dependencies of target cpp-exe
[ 50%] Building CXX object test/rust2cpp/CMakeFiles/cpp-exe.dir/main.cpp.o
[ 66%] Linking CXX executable cpp-exe
[ 66%] Built target cpp-exe
Scanning dependencies of target cargo-build_member2
   Compiling member2 v0.1.0 (/home/vagrant/corrosion/test/workspace/member2)
    Finished release [optimized] target(s) in 0.04s
[ 66%] Built target cargo-build_member2
Scanning dependencies of target cargo-build_member1
   Compiling member1 v0.1.0 (/home/vagrant/corrosion/test/workspace/member1)
    Finished release [optimized] target(s) in 0.11s
[ 66%] Built target cargo-build_member1
Scanning dependencies of target my_program
[ 83%] Building CXX object test/workspace/CMakeFiles/my_program.dir/main.cpp.o
[100%] Linking CXX executable my_program
[100%] Built target my_program
Scanning dependencies of target test-install
-- The CXX compiler identification is GNU 8.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.55.0 (c8dfcfe04 2021-09-06)`
-- Rust Toolchain: stable-x86_64-unknown-linux-gnu
VERBOSERust toolchain stable-x86_64-unknown-linux-gnu
VERBOSERust toolchain path /home/vagrant/.rustup/toolchains/stable-x86_64-unknown-linux-gnu
-- Rust Target: x86_64-unknown-linux-gnu
-- Found Rust: /home/vagrant/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc (found version "1.55.0") 
-- Defaulting Cargo to build debug
-- Configuring done
-- Generating done
-- Build files have been written to: /home/vagrant/build/test/config/test-build
Scanning dependencies of target cargo-build_corrosion-generator
   Compiling proc-macro2 v1.0.26
   Compiling unicode-xid v0.2.1
   Compiling syn v1.0.71
   Compiling serde_derive v1.0.125
   Compiling serde v1.0.125
   Compiling ryu v1.0.5
   Compiling ucd-trie v0.1.3
   Compiling bitflags v1.2.1
   Compiling camino v1.0.4
   Compiling serde_json v1.0.64
   Compiling unicode-width v0.1.8
   Compiling platforms v1.1.0
   Compiling itoa v0.4.7
   Compiling pest v2.1.3
   Compiling textwrap v0.11.0
   Compiling quote v1.0.9
   Compiling semver-parser v0.10.2
   Compiling clap v2.33.3
   Compiling cargo-platform v0.1.1
   Compiling semver v0.11.0
   Compiling cargo_metadata v0.13.1
   Compiling corrosion-generator v0.1.0 (/home/vagrant/corrosion/generator)
    Finished dev [unoptimized + debuginfo] target(s) in 23.09s
Built target cargo-build_corrosion-generator
CMake Error: The source directory "/home/vagrant/build/test/config/Debug" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
make[2]: *** [test/config/CMakeFiles/test-install.dir/build.make:59: test/config/CMakeFiles/test-install] Error 1
make[1]: *** [CMakeFiles/Makefile2:1570: test/config/CMakeFiles/test-install.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
</details>

Edit: Manually generating the test files and the "Release" directory via `mkdir` lets corrosion build and install successfully.