### PR TITLE
make FindRust gracefully fail if rustc not found

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -166,9 +166,19 @@ if (_RESOLVE_RUSTUP_TOOLCHAINS)
             NO_DEFAULT_PATH)
 else()
     find_program(Rust_COMPILER_CACHED rustc)
+    if (Rust_COMPILER_CACHED)
+        get_filename_component(_RUST_TOOLCHAIN_PATH ${Rust_COMPILER_CACHED} DIRECTORY)
+        get_filename_component(_RUST_TOOLCHAIN_PATH ${_RUST_TOOLCHAIN_PATH} DIRECTORY)
+    endif()
+endif()
 
-    get_filename_component(_RUST_TOOLCHAIN_PATH ${Rust_COMPILER_CACHED} DIRECTORY)
-    get_filename_component(_RUST_TOOLCHAIN_PATH ${_RUST_TOOLCHAIN_PATH} DIRECTORY)
+if (NOT Rust_COMPILER_CACHED)
+    message(
+        WARNING "The rustc executable was not found. "
+        "Rust not installed or ~/.cargo/bin not added to path? "
+        "Aborting further actions of find_package(Rust). ")
+    set(Rust_FOUND false)
+    return()
 endif()
 
 # Look for Cargo next to rustc.
@@ -352,4 +362,5 @@ if(NOT TARGET Rust::Rustc)
         TARGET Rust::Cargo
         PROPERTY IMPORTED_LOCATION ${Rust_CARGO_CACHED}
     )
+    set(Rust_FOUND true)
 endif()


### PR DESCRIPTION
Motivation for this change is to be able to reuse the FindRust module in a more general setting to see if rust exists.
With this change, it should be able to be used by any other package and afterwards check Rust_FOUND of its existence.

Earlier a missing .cargo/bin/rustc would fail with
```
The system cannot find the file specified
CMake Error at corrosion/cmake/FindRust.cmake:171 (get_filename_component):
  get_filename_component called with incorrect number of arguments
```
Now it prints a more descriptive errormessage, sets Rust_FOUND to false
and returns.
It also sets Rust_FOUND to true if a rust target is successfully created