### PR TITLE
Relax Cargo version parsing

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -198,6 +198,12 @@ if (_CARGO_VERSION_RAW MATCHES "cargo ([0-9]+)\\.([0-9]+)\\.([0-9]+)")
     set(Rust_CARGO_VERSION_MINOR "${CMAKE_MATCH_2}")
     set(Rust_CARGO_VERSION_PATCH "${CMAKE_MATCH_3}")
     set(Rust_CARGO_VERSION "${Rust_CARGO_VERSION_MAJOR}.${Rust_CARGO_VERSION_MINOR}.${Rust_CARGO_VERSION_PATCH}")
+# Workaround for the version strings where the `cargo ` prefix is missing.
+elseif(_CARGO_VERSION_RAW MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(Rust_CARGO_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(Rust_CARGO_VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(Rust_CARGO_VERSION_PATCH "${CMAKE_MATCH_3}")
+    set(Rust_CARGO_VERSION "${Rust_CARGO_VERSION_MAJOR}.${Rust_CARGO_VERSION_MINOR}.${Rust_CARGO_VERSION_PATCH}")
 else()
     message(
         FATAL_ERROR


### PR DESCRIPTION
Some cargo versions shipped with rust nightlies seem to be reporting their version without the cargo prefix, e.g.:
```
$ cargo +nightly-2021-07-24 --version
1.55.0-nightly (cebef2951 2021-07-22)
```

 This commit relaxes the parsing slightly by adding an elseif
 condition that matches on the expression without the leading
 `cargo `. It's not an elegant solution, but it works for now.

______________

This is just a quick workaround from my side, but I'm open to suggestions if you would like a more thorough fix.